### PR TITLE
Correct parsing of label expressions and acceptance conditions.

### DIFF
--- a/hoa2dot/core.py
+++ b/hoa2dot/core.py
@@ -259,7 +259,7 @@ class AndLabelExpression(LabelExpression):
 
     def __str__(self):
         """Transform the AndLabelExpression to string."""
-        return " & ".join(map(str, self.subexpressions))
+        return "(" + " & ".join(map(str, self.subexpressions)) + ")"
 
     def __eq__(self, other):
         """Check equality between two AndLabelExpressions."""
@@ -293,7 +293,7 @@ class OrLabelExpression(LabelExpression):
 
     def __str__(self):
         """Transform the OrLabelExpression to string."""
-        return " | ".join(map(str, self.subexpressions))
+        return "(" + " | ".join(map(str, self.subexpressions)) + ")"
 
     def __eq__(self, other):
         """Check equality between two OrLabelExpressions."""
@@ -356,7 +356,7 @@ class NotLabelExpression(LabelExpression):
 
     def __str__(self):
         """Transform the NotLabelExpression to string."""
-        return "!" + str(self.subexpression)
+        return "!({})".format(str(self.subexpression))
 
     def __eq__(self, other):
         """Check equality between two NotLabelExpressions."""
@@ -653,6 +653,21 @@ class HOAHeader:
 
         return s
 
+    def __eq__(self, other):
+        """Check equality between two HOA bodies."""
+        return isinstance(other, HOAHeader) \
+            and self.format_version == other.format_version \
+            and self.acceptance == other.acceptance \
+            and self.nb_states == other.nb_states \
+            and self.start_states == other.start_states \
+            and self.aliases == other.aliases \
+            and self.acceptance_name == other.acceptance_name \
+            and self.propositions == other.propositions \
+            and self.tool == other.tool \
+            and self.name == other.name \
+            and self.properties == other.properties \
+            and self.headernames == other.headernames
+
 
 class HOABody:
     """This class implements a data structure for the HOA file format header."""
@@ -673,6 +688,10 @@ class HOABody:
         """
         return "\n".join([state.to_hoa_repr() + "\n" + "\n".join(map(lambda x: x.to_hoa_repr(), edges))
                           for state, edges in self.state2edges.items()]) + "\n"
+
+    def __eq__(self, other):
+        """Check equality between two HOA bodies."""
+        return isinstance(other, HOABody) and self.state2edges == other.state2edges
 
 
 class HOA:
@@ -706,3 +725,7 @@ class HOA:
         header = self.header.dumps()
         body = self.body.dumps()
         return header + "--BODY--\n" + body + "--END--"
+
+    def __eq__(self, other):
+        """Check equality between two HOA bodies."""
+        return isinstance(other, HOA) and self.header == other.header and self.body == other.body

--- a/hoa2dot/core.py
+++ b/hoa2dot/core.py
@@ -654,7 +654,7 @@ class HOAHeader:
         return s
 
     def __eq__(self, other):
-        """Check equality between two HOA bodies."""
+        """Check equality between two HOA headers."""
         return isinstance(other, HOAHeader) \
             and self.format_version == other.format_version \
             and self.acceptance == other.acceptance \

--- a/hoa2dot/grammars/hoa.lark
+++ b/hoa2dot/grammars/hoa.lark
@@ -34,23 +34,27 @@ label:  "[" label_expr "]"
 
 
 state_conj : INT | state_conj "&" INT
-label_expr : boolean_label_expr | atom_label_expr | alias_label_expr | not_label_expr
-           | "(" label_expr ")"
-           | and_label_expr
+label_expr : "(" label_expr ")"
            | or_label_expr
-or_label_expr.2: label_expr "|" label_expr
-and_label_expr.1: label_expr "&" label_expr
+           | and_label_expr
+           | not_label_expr
+           | atom_label_expr
+           | boolean_label_expr
+           | alias_label_expr
+
+or_label_expr: label_expr "|" label_expr
+and_label_expr: label_expr "&" label_expr
 not_label_expr: "!" label_expr
 alias_label_expr: ANAME
 atom_label_expr: INT
 boolean_label_expr: BOOLEAN
 
-acceptance_cond : atom_acceptance_cond
-                | not_acceptance_cond
-                | and_acceptance_cond
+acceptance_cond : "(" acceptance_cond ")"
                 | or_acceptance_cond
+                | and_acceptance_cond
+                | not_acceptance_cond
                 | boolean_acceptance_cond
-                | "(" acceptance_cond ")"
+                | atom_acceptance_cond
 or_acceptance_cond.2 : acceptance_cond "|" acceptance_cond
 and_acceptance_cond.1 : acceptance_cond "&" acceptance_cond
 not_acceptance_cond : IDENTIFIER "(" "!" INT ")"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 import pytest
 
 from hoa2dot.core import HOA, Acceptance, Atom, AtomType, And, TrueAcceptance, AliasLabelExpression, \
-    AtomLabelExpression, AndLabelExpression, NotLabelExpression, State, Edge, TrueLabelExpression
+    AtomLabelExpression, AndLabelExpression, NotLabelExpression, State, Edge, TrueLabelExpression, HOABody
 from hoa2dot.parsers import HOAParser
 
 from .conftest import TEST_ROOT_DIR
@@ -35,9 +35,8 @@ def test_parsing_is_deterministic(filepath):
     hoa_obj_1 = parser(open(filepath).read())  # type: HOA
     temp = tempfile.mktemp()
     hoa_obj_1.dump(open(temp, "w"))
-    # hoa_obj_2 = parser(open(temp).read())
-    # TODO equality check does not work yet
-    # assert hoa_obj_1 == hoa_obj_2
+    hoa_obj_2 = parser(open(temp).read())
+    assert hoa_obj_1 == hoa_obj_2
 
 
 class TestParsingAut1:
@@ -102,7 +101,7 @@ class TestParsingAut2:
     def setup_class(cls):
         """Set the test up."""
         parser = HOAParser()
-        cls.hoa_obj = parser(open(str(Path(TEST_ROOT_DIR, "examples", "aut2.hoa"))).read())  # type: HOA
+        cls.hoa_obj = parser(open(str(Path(TEST_ROOT_DIR, "examples", "aut3.2.hoa"))).read())  # type: HOA
         cls.hoa_header = cls.hoa_obj.header
         cls.hoa_body = cls.hoa_obj.body
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -2,15 +2,14 @@
 """Test the parsing module."""
 import os
 import tempfile
-from pathlib import Path
 from collections import OrderedDict
+from pathlib import Path
 
 import pytest
 
 from hoa2dot.core import HOA, Acceptance, Atom, AtomType, And, TrueAcceptance, AliasLabelExpression, \
-    AtomLabelExpression, AndLabelExpression, NotLabelExpression, State, Edge, TrueLabelExpression, HOABody
+    AtomLabelExpression, AndLabelExpression, NotLabelExpression, State, Edge, TrueLabelExpression
 from hoa2dot.parsers import HOAParser
-
 from .conftest import TEST_ROOT_DIR
 
 
@@ -101,7 +100,7 @@ class TestParsingAut2:
     def setup_class(cls):
         """Set the test up."""
         parser = HOAParser()
-        cls.hoa_obj = parser(open(str(Path(TEST_ROOT_DIR, "examples", "aut3.2.hoa"))).read())  # type: HOA
+        cls.hoa_obj = parser(open(str(Path(TEST_ROOT_DIR, "examples", "aut2.hoa"))).read())  # type: HOA
         cls.hoa_header = cls.hoa_obj.header
         cls.hoa_body = cls.hoa_obj.body
 


### PR DESCRIPTION
This PR aims to fix #6 by sorting the grammar rules for `label_expr` and `acceptance_cond` correctly.

It is related to issue lark-parser/lark#502 that aims to clarify the usage of rule priorities in the Earley parser.

